### PR TITLE
Update setuptools (supports Debian Jessie)

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - xenial
+    - name: Debian
+      versions:
+        - jessie
 
   galaxy_tags: 
     - flexget

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,14 @@
 ---
 # tasks file for roles/flexget-daemon
 
+- name: Update apt cache.
+  apt: update_cache=yes cache_valid_time=86400
+
 - name: ensure pip is installed
   apt: name=python-pip state=latest
+
+- name: ensure setuptools is installed
+  pip: name=setuptools state=latest
 
 - name: ensure flexget is installed
   pip: name=flexget state=latest


### PR DESCRIPTION
Small change for those running Debian Jessie to make sure that setuptools is the right version for the latest version of FlexGet in the pip repo.
