### PR TITLE
Fix for Debian Jessie pip dependency collisions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,14 @@ services: docker
 
 install:
   - docker run -d --name target -v $PWD:/flexget-daemon --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro debian:jessie /sbin/init
-  - docker exec target sh -c "apt-get update && apt-get install python-pip python-dev libffi-dev libssl-dev sudo curl lsof -y && pip install -U setuptools && pip install ansible markupsafe" 
+  - docker exec target sh -c "apt-get update && apt-get install python-pip python-dev libffi-dev libssl-dev sudo curl lsof -y && pip install -U setuptools && pip install ansible markupsafe"
 
 script:
   - docker exec target ansible-playbook /flexget-daemon/tests/test.yml -i /flexget-daemon/tests/inventory --syntax-check
   - docker exec target ansible-playbook /flexget-daemon/tests/test.yml -i /flexget-daemon/tests/inventory --connection=local --sudo
   - docker exec target pgrep flexget
+
+  - docker exec target ansible-playbook /flexget-daemon/tests/test.yml -i /flexget-daemon/tests/inventory --connection=local --sudo
 
   # not working at the moment as the docker container doesnt seem to want to start up any ports.  needs fixing.
   # - docker exec target curl -ILfsv 127.0.0.1:3539/api/

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,10 @@
 # tasks file for roles/flexget-daemon
 
 - name: ensure pip is installed
-  apt: name=python-pip state=latest update_cache=yes cache_valid_time=86400
+  apt: name=python-pip state=present update_cache=yes cache_valid_time=86400
+
+- name: ensure pip is the latest version
+  pip: name=pip state=latest
 
 - name: ensure setuptools is installed
   pip: name=setuptools state=latest


### PR DESCRIPTION
Found this issue when I tried to follow this role with a `pip` task in my Ansible playbook, but another way to uncover it is to rerun the role on your target:

```
TASK [flexget-daemon : ensure setuptools is installed] *************************
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/usr/bin/pip install -U setuptools", "failed": true, "msg": "\n:stderr: Traceback (most recent call last):\n  File \"/usr/bin/pip\", line 9, in <module>\n    load_entry_point('pip==1.5.6', 'console_scripts', 'pip')()\n  File \"/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py\", line 565, in load_entry_point\n    return get_distribution(dist).load_entry_point(group, name)\n  File \"/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py\", line 2598, in load_entry_point\n    return ep.load()\n  File \"/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py\", line 2258, in load\n    return self.resolve()\n  File \"/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py\", line 2264, in resolve\n    module = __import__(self.module_name, fromlist=['__name__'], level=0)\n  File \"/usr/lib/python2.7/dist-packages/pip/__init__.py\", line 74, in <module>\n    from pip.vcs import git, mercurial, subversion, bazaar  # noqa\n  File \"/usr/lib/python2.7/dist-packages/pip/vcs/mercurial.py\", line 9, in <module>\n    from pip.download import path_to_url\n  File \"/usr/lib/python2.7/dist-packages/pip/download.py\", line 25, in <module>\n    from requests.compat import IncompleteRead\nImportError: cannot import name IncompleteRead\n"}
```

This happens because the version of [pip in the Debian Jessie apt repo (1.5.6-5)](https://packages.debian.org/jessie/python-pip) depends on and is distrubted via apt with v2.4.3 of the requests package.  When FlexGet is installed via pip, pip overrides the version of requests with the latest ([v2.11.1 as of this post](https://pypi.python.org/pypi/requests/2.11.1)).

This affects all versions of [Ubuntu prior to Xenial (16.04)](http://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=python-pip&searchon=names) and all versions of Debian and Debian-based distros such as Raspbian.

There may be a better way to address this using a configurable `virtualenv` environment.  But this was a quicker fix.  If you'd prefer I go back and do it via virtualenv, let me know.

[![Build Status](https://travis-ci.org/robgmills/flexget-daemon.svg?branch=debian-pip-deps-collision)](https://travis-ci.org/robgmills/flexget-daemon)
